### PR TITLE
separating questions and answers

### DIFF
--- a/workshops/postgis/source/en/geometries.rst
+++ b/workshops/postgis/source/en/geometries.rst
@@ -11,14 +11,14 @@ In the previous :ref:`section <loading_data>`, we loaded a variety of data.  Bef
 .. code-block:: sql
 
   CREATE TABLE geometries (name varchar, geom geometry);
-  
-  INSERT INTO geometries VALUES 
+
+  INSERT INTO geometries VALUES
     ('Point', 'POINT(0 0)'),
     ('Linestring', 'LINESTRING(0 0, 1 1, 2 1, 2 2)'),
     ('Polygon', 'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'),
     ('PolygonWithHole', 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))'),
     ('Collection', 'GEOMETRYCOLLECTION(POINT(2 0),POLYGON((0 0, 1 0, 1 1, 0 1, 0 0)))');
-    
+
   SELECT name, ST_AsText(geom) FROM geometries;
 
 .. image:: ./geometries/start01.png
@@ -28,10 +28,10 @@ The above example CREATEs a table (**geometries**) then INSERTs five geometries:
 Metadata Tables
 ---------------
 
-In conformance with the Simple Features for SQL (:term:`SFSQL`) specification, PostGIS provides two tables to track and report on the geometry types available in a given database. 
+In conformance with the Simple Features for SQL (:term:`SFSQL`) specification, PostGIS provides two tables to track and report on the geometry types available in a given database.
 
-* The first table, ``spatial_ref_sys``, defines all the spatial reference systems known to the database and will be described in greater detail later.  
-* The second table (actually, a view), ``geometry_columns``, provides a listing of all "features" (defined as an object with geometric attributes), and the basic details of those features.  
+* The first table, ``spatial_ref_sys``, defines all the spatial reference systems known to the database and will be described in greater detail later.
+* The second table (actually, a view), ``geometry_columns``, provides a listing of all "features" (defined as an object with geometric attributes), and the basic details of those features.
 
 .. image:: ./geometries/table01.png
   :class: inline
@@ -44,25 +44,25 @@ Let's have a look at the ``geometry_columns`` table in our database.  Paste this
 
 .. image:: ./geometries/start08.png
 
-* ``f_table_catalog``, ``f_table_schema``, and ``f_table_name`` provide the fully qualified name of the feature table containing a given geometry.  Because PostgreSQL doesn't make use of catalogs, ``f_table_catalog`` will tend to be empty.  
-* ``f_geometry_column`` is the name of the column that geometry containing column -- for feature tables with multiple geometry columns, there will be one record for each.  
-* ``coord_dimension`` and ``srid`` define the the dimension of the geometry (2-, 3- or 4-dimensional) and the Spatial Reference system identifier that refers to the ``spatial_ref_sys`` table respectively.  
-* The ``type`` column defines the type of geometry as described below; we've seen Point and Linestring types so far.  
+* ``f_table_catalog``, ``f_table_schema``, and ``f_table_name`` provide the fully qualified name of the feature table containing a given geometry.  Because PostgreSQL doesn't make use of catalogs, ``f_table_catalog`` will tend to be empty.
+* ``f_geometry_column`` is the name of the column that geometry containing column -- for feature tables with multiple geometry columns, there will be one record for each.
+* ``coord_dimension`` and ``srid`` define the the dimension of the geometry (2-, 3- or 4-dimensional) and the Spatial Reference system identifier that refers to the ``spatial_ref_sys`` table respectively.
+* The ``type`` column defines the type of geometry as described below; we've seen Point and Linestring types so far.
 
 By querying this table, GIS clients and libraries can determine what to expect when retrieving data and can perform any necessary projection, processing or rendering without needing to inspect each geometry.
 
 .. note::
 
-   Do some or all of your ``nyc`` tables not have an ``srid`` of 26918? It's easy to fix by updating the table::
+   Do some or all of your ``nyc`` tables not have an ``srid`` of 26918? It's easy to fix by updating the table
 
    .. code-block:: sql
-  
-      SELECT UpdateGeometrySRID('nyc_neighborhoods','geom',26918);
+
+      SELECT UpdateGeometrySRID('nyc_neighborhoods','geom',26918);::
 
 Representing Real World Objects
 -------------------------------
 
-The Simple Features for SQL (:term:`SFSQL`) specification, the original guiding standard for PostGIS development, defines how a real world object is represented.  By taking a continuous shape and digitizing it at a fixed resolution we achieve a passable representation of the object.  SFSQL only handled 2-dimensional representations.  PostGIS has extended that to include 3- and 4-dimensional representations; more recently the SQL-Multimedia Part 3 (:term:`SQL/MM`) specification has officially defined their own representation.  
+The Simple Features for SQL (:term:`SFSQL`) specification, the original guiding standard for PostGIS development, defines how a real world object is represented.  By taking a continuous shape and digitizing it at a fixed resolution we achieve a passable representation of the object.  SFSQL only handled 2-dimensional representations.  PostGIS has extended that to include 3- and 4-dimensional representations; more recently the SQL-Multimedia Part 3 (:term:`SQL/MM`) specification has officially defined their own representation.
 
 Our example table contains a mixture of different geometry types. We can collect general information about each object using functions that read the geometry metadata.
 
@@ -77,7 +77,7 @@ Our example table contains a mixture of different geometry types. We can collect
 
 ::
 
-       name       |    st_geometrytype    | st_ndims | st_srid 
+       name       |    st_geometrytype    | st_ndims | st_srid
  -----------------+-----------------------+----------+---------
   Point           | ST_Point              |        2 |       0
   Polygon         | ST_Polygon            |        2 |       0
@@ -93,11 +93,11 @@ Points
   :align: center
   :class: inline
 
-A spatial **point** represents a single location on the Earth.  This point is represented by a single coordinate (including either 2-, 3- or 4-dimensions).  Points are used to represent objects when the exact details, such as shape and size, are not important at the target scale.  For example, cities on a map of the world can be described as points, while a map of a single state might represent cities as polygons.  
+A spatial **point** represents a single location on the Earth.  This point is represented by a single coordinate (including either 2-, 3- or 4-dimensions).  Points are used to represent objects when the exact details, such as shape and size, are not important at the target scale.  For example, cities on a map of the world can be described as points, while a map of a single state might represent cities as polygons.
 
 .. code-block:: sql
 
-  SELECT ST_AsText(geom) 
+  SELECT ST_AsText(geom)
     FROM geometries
     WHERE name = 'Point';
 
@@ -142,10 +142,10 @@ The following SQL query will return the geometry associated with one linestring 
 
 .. code-block:: sql
 
-  SELECT ST_AsText(geom) 
+  SELECT ST_AsText(geom)
     FROM geometries
     WHERE name = 'Linestring';
-  
+
 ::
 
   LINESTRING(0 0, 1 1, 2 1, 2 2)
@@ -161,7 +161,7 @@ So, the length of our linestring is:
 
 .. code-block:: sql
 
-  SELECT ST_Length(geom) 
+  SELECT ST_Length(geom)
     FROM geometries
     WHERE name = 'Linestring';
 
@@ -185,7 +185,7 @@ The following SQL query will return the geometry associated with one linestring 
 
 .. code-block:: sql
 
-  SELECT ST_AsText(geom) 
+  SELECT ST_AsText(geom)
     FROM geometries
     WHERE name LIKE 'Polygon%';
 
@@ -214,7 +214,7 @@ We can calculate the area of our polygons using the area function:
 
 .. code-block:: sql
 
-  SELECT name, ST_Area(geom) 
+  SELECT name, ST_Area(geom)
     FROM geometries
     WHERE name LIKE 'Polygon%';
 
@@ -228,7 +228,7 @@ Note that the polygon with a hole has an area that is the area of the outer shel
 Collections
 ~~~~~~~~~~~
 
-There are four collection types, which group multiple simple geometries into sets.  
+There are four collection types, which group multiple simple geometries into sets.
 
 * **MultiPoint**, a collection of points
 * **MultiLineString**, a collection of linestrings
@@ -243,7 +243,7 @@ Our example collection contains a polygon and a point:
 
 .. code-block:: sql
 
-  SELECT name, ST_AsText(geom) 
+  SELECT name, ST_AsText(geom)
     FROM geometries
     WHERE name = 'Collection';
 
@@ -268,56 +268,56 @@ Geometry Input and Output
 Within the database, geometries are stored on disk in a format only used by the PostGIS program. In order for external programs to insert and retrieve useful geometries, they need to be converted into a format that other applications can understand. Fortunately, PostGIS supports emitting and consuming geometries in a large number of formats:
 
 * Well-known text (:term:`WKT`)
- 
+
   * :command:`ST_GeomFromText(text, srid)` returns ``geometry``
   * :command:`ST_AsText(geometry)` returns ``text``
   * :command:`ST_AsEWKT(geometry)` returns ``text``
-   
+
 * Well-known binary (:term:`WKB`)
- 
+
   * :command:`ST_GeomFromWKB(bytea)` returns ``geometry``
   * :command:`ST_AsBinary(geometry)` returns ``bytea``
   * :command:`ST_AsEWKB(geometry)` returns ``bytea``
-   
+
 * Geographic Mark-up Language (:term:`GML`)
- 
+
   * :command:`ST_GeomFromGML(text)` returns ``geometry``
   * :command:`ST_AsGML(geometry)` returns ``text``
-   
+
 * Keyhole Mark-up Language (:term:`KML`)
- 
+
   * :command:`ST_GeomFromKML(text)` returns ``geometry``
   * :command:`ST_AsKML(geometry)` returns ``text``
-   
+
 * :term:`GeoJSON`
- 
+
   * :command:`ST_AsGeoJSON(geometry)` returns ``text``
-   
+
 * Scalable Vector Graphics (:term:`SVG`)
- 
+
   * :command:`ST_AsSVG(geometry)` returns ``text``
- 
+
 The most common use of a constructor is to turn a text representation of a geometry into an internal representation:
 
 .. code-block::sql
 
   SELECT ST_GeomFromText('POINT(583571 4506714)',26918);
- 
+
 Note that in addition to a text parameter with a geometry representation, we also have a numeric parameter providing the :term:`SRID` of the geometry.
- 
+
 The following SQL query shows an example of :term:`WKB` representation (the call to :command:`encode()` is required to convert the binary output into an ASCII form for printing):
 
 .. code-block:: sql
 
   SELECT encode(
-    ST_AsBinary(ST_GeometryFromText('LINESTRING(0 0,1 0)')), 
+    ST_AsBinary(ST_GeometryFromText('LINESTRING(0 0,1 0)')),
     'hex');
 
 ::
 
   01020000000200000000000000000000000000000000000000000000000000f03f0000000000000000
-  
-For the purposes of this workshop we will continue to use WKT to ensure you can read and understand the geometries we're viewing.  However, most actual processes, such as viewing data in a GIS application, transferring data to a web service, or processing data remotely, WKB is the format of choice.  
+
+For the purposes of this workshop we will continue to use WKT to ensure you can read and understand the geometries we're viewing.  However, most actual processes, such as viewing data in a GIS application, transferring data to a web service, or processing data remotely, WKB is the format of choice.
 
 Since WKT and WKB were defined in the  :term:`SFSQL` specification, they do not handle 3- or 4-dimensional geometries.  For these cases PostGIS has defined the Extended Well Known Text (EWKT) and Extended Well Known Binary (EWKB) formats.  These provide the same formatting capabilities of WKT and WKB with the added dimensionality.
 
@@ -331,10 +331,10 @@ Here is an example of a 3D linestring in WKT:
 
   LINESTRING Z (0 0 0,1 0 0,1 1 2)
 
-Note that the text representation changes! This is because the text input routine for PostGIS is liberal in what it consumes. It will consume 
+Note that the text representation changes! This is because the text input routine for PostGIS is liberal in what it consumes. It will consume
 
-* hex-encoded EWKB, 
-* extended well-known text, and 
+* hex-encoded EWKB,
+* extended well-known text, and
 * ISO standard well-known text.
 
 On the output side, the :command:`ST_AsText` function is conservative, and only emits ISO standard well-known text.
@@ -348,17 +348,17 @@ In addition to the :command:`ST_GeometryFromText` function, there are many other
 
   -- Using ST_GeomFromText without the SRID parameter
   SELECT ST_SetSRID(ST_GeomFromText('POINT(2 2)'),4326);
-  
+
   -- Using a ST_Make* function
   SELECT ST_SetSRID(ST_MakePoint(2, 2), 4326);
-  
+
   -- Using PostgreSQL casting syntax and ISO WKT
   SELECT ST_SetSRID('POINT(2 2)'::geometry, 4326);
-  
+
   -- Using PostgreSQL casting syntax and extended WKT
   SELECT 'SRID=4326;POINT(2 2)'::geometry;
 
-  
+
 In addition to emitters for the various forms (WKT, WKB, GML, KML, JSON, SVG), PostGIS also has consumers for four (WKT, WKB, GML, KML). Most applications use the WKT or WKB geometry creation functions, but the others work too. Here's an example that consumes GML and output JSON:
 
 .. code-block:: sql
@@ -371,7 +371,7 @@ In addition to emitters for the various forms (WKT, WKB, GML, KML, JSON, SVG), P
 Casting from Text
 -----------------
 
-The :term:`WKT` strings we've see so far have been of type 'text' and we have been converting them to type 'geometry' using PostGIS functions like :command:`ST_GeomFromText()`. 
+The :term:`WKT` strings we've see so far have been of type 'text' and we have been converting them to type 'geometry' using PostGIS functions like :command:`ST_GeomFromText()`.
 
 PostgreSQL includes a short form syntax that allows data to be converted from one type to another, the casting syntax, `oldata::newtype`. So for example, this SQL converts a double into a text string.
 
@@ -452,5 +452,3 @@ Function List
 `ST_X <http://postgis.net/docs/manual-2.1/ST_X.html>`_: Returns the X coordinate of the point, or NULL if not available. Input must be a point.
 
 `ST_Y <http://postgis.net/docs/manual-2.1/ST_Y.html>`_: Returns the Y coordinate of the point, or NULL if not available. Input must be a point.
-
-

--- a/workshops/postgis/source/en/geometries.rst
+++ b/workshops/postgis/source/en/geometries.rst
@@ -57,7 +57,7 @@ By querying this table, GIS clients and libraries can determine what to expect w
 
    .. code-block:: sql
 
-      SELECT UpdateGeometrySRID('nyc_neighborhoods','geom',26918);::
+      SELECT UpdateGeometrySRID('nyc_neighborhoods','geom',26918);
 
 Representing Real World Objects
 -------------------------------

--- a/workshops/postgis/source/en/geometries_exercise_answers.rst
+++ b/workshops/postgis/source/en/geometries_exercise_answers.rst
@@ -1,0 +1,162 @@
+.. _geometries_exercise_answers:
+
+Geometry Exercise Answers
+=========================
+
+
+Exercises with answers
+----------------------
+
+* **"What is the area of the 'West Village' neighborhood?"**
+
+  .. code-block:: sql
+
+    SELECT ST_Area(geom)
+      FROM nyc_neighborhoods
+      WHERE name = 'West Village';
+
+  ::
+
+    1044614.5296486
+
+  .. note::
+
+    The area is given in square meters. To get an area in hectares, divide by 10000. To get an area in acres, divide by 4047.
+
+* **"What is the area of Manhattan in acres?"** (Hint: both ``nyc_census_blocks`` and ``nyc_neighborhoods`` have a ``boroname`` in them.)
+
+  .. code-block:: sql
+
+    SELECT Sum(ST_Area(geom)) / 4047
+      FROM nyc_neighborhoods
+      WHERE boroname = 'Manhattan';
+
+  ::
+
+    13965.3201224118
+
+  or...
+
+  .. code-block:: sql
+
+    SELECT Sum(ST_Area(geom)) / 4047
+      FROM nyc_census_blocks
+      WHERE boroname = 'Manhattan';
+
+  ::
+
+    14601.3987215548
+
+
+* **"How many census blocks in New York City have a hole in them?"**
+
+  .. code-block:: sql
+
+    SELECT Count(*)
+      FROM nyc_census_blocks
+      WHERE ST_NumInteriorRings(ST_GeometryN(geom,1)) > 0;
+
+  .. note::
+
+    The ST_NRings() functions might be tempting, but it also counts the exterior rings of multi-polygons as well as interior rings.  In order to run ST_NumInteriorRings() we need to convert the MultiPolygon geometries of the blocks into simple polygons, so we extract the first polygon from each collection using ST_GeometryN(). Yuck!
+
+  ::
+
+    43
+
+* **"What is the total length of streets (in kilometers) in New York City?"** (Hint: The units of measurement of the spatial data are meters, there are 1000 meters in a kilometer.)
+
+  .. code-block:: sql
+
+    SELECT Sum(ST_Length(geom)) / 1000
+      FROM nyc_streets;
+
+  ::
+
+    10418.9047172
+
+* **"How long is 'Columbus Cir' (Columbus Circle)?**
+
+  .. code-block:: sql
+
+    SELECT ST_Length(geom)
+      FROM nyc_streets
+      WHERE name = 'Columbus Cir';
+
+  ::
+
+    308.34199
+
+* **"What is the JSON representation of the boundary of the 'West Village'?"**
+
+  .. code-block:: sql
+
+    SELECT ST_AsGeoJSON(geom)
+      FROM nyc_neighborhoods
+      WHERE name = 'West Village';
+
+  ::
+
+    {"type":"MultiPolygon","coordinates":
+     [[[[583263.2776595836,4509242.6260239873],
+        [583276.81990686338,4509378.825446927], ...
+        [583263.2776595836,4509242.6260239873]]]]}
+
+  The geometry type is "MultiPolygon", interesting!
+
+* **"How many polygons are in the 'West Village' multipolygon?"**
+
+  .. code-block:: sql
+
+    SELECT ST_NumGeometries(geom)
+      FROM nyc_neighborhoods
+      WHERE name = 'West Village';
+
+  ::
+
+    1
+
+  .. note::
+
+    It is not uncommon to find single-element MultiPolygons in spatial tables. Using MultiPolygons allows a table with only one geometry type to store both single- and multi-geometries without using mixed types.
+
+
+* **"What is the length of streets in New York City, summarized by type?"**
+
+  .. code-block:: sql
+
+    SELECT type, Sum(ST_Length(geom)) AS length
+    FROM nyc_streets
+    GROUP BY type
+    ORDER BY length DESC;
+
+  ::
+
+                           type                       |      length
+    --------------------------------------------------+------------------
+     residential                                      | 8629870.33786606
+     motorway                                         | 403622.478126363
+     tertiary                                         | 360394.879051303
+     motorway_link                                    | 294261.419479668
+     secondary                                        | 276264.303897926
+     unclassified                                     | 166936.371604458
+     primary                                          | 135034.233017947
+     footway                                          | 71798.4878378096
+     service                                          |  28337.635038596
+     trunk                                            | 20353.5819826076
+     cycleway                                         | 8863.75144825929
+     pedestrian                                       | 4867.05032825026
+     construction                                     | 4803.08162103562
+     residential; motorway_link                       | 3661.57506293745
+     trunk_link                                       | 3202.18981240201
+     primary_link                                     | 2492.57457083536
+     living_street                                    | 1894.63905457332
+     primary; residential; motorway_link; residential | 1367.76576941335
+     undefined                                        |  380.53861910346
+     steps                                            | 282.745221342127
+     motorway_link; residential                       |  215.07778911517
+
+
+  .. note::
+
+    The ``ORDER BY length DESC`` clause sorts the result by length in descending order. The result is that most prevalent types are first in the list.

--- a/workshops/postgis/source/en/geometries_exercises.rst
+++ b/workshops/postgis/source/en/geometries_exercises.rst
@@ -38,177 +38,37 @@ Here's a reminder of all the functions we have seen so far. They should be usefu
 
 Also remember the tables we have available:
 
-* ``nyc_census_blocks`` 
- 
+* ``nyc_census_blocks``
+
   * blkid, popn_total, boroname, geom
- 
+
 * ``nyc_streets``
- 
+
   * name, type, geom
-   
+
 * ``nyc_subway_stations``
- 
+
   * name, geom
- 
+
 * ``nyc_neighborhoods``
- 
+
   * name, boroname, geom
 
 Exercises
 ---------
 
 * **"What is the area of the 'West Village' neighborhood?"**
- 
-  .. code-block:: sql
-
-    SELECT ST_Area(geom)
-      FROM nyc_neighborhoods
-      WHERE name = 'West Village';
-       
-  :: 
-
-    1044614.5296486
-
-  .. note::
-
-    The area is given in square meters. To get an area in hectares, divide by 10000. To get an area in acres, divide by 4047.
 
 * **"What is the area of Manhattan in acres?"** (Hint: both ``nyc_census_blocks`` and ``nyc_neighborhoods`` have a ``boroname`` in them.)
- 
-  .. code-block:: sql
-
-    SELECT Sum(ST_Area(geom)) / 4047
-      FROM nyc_neighborhoods
-      WHERE boroname = 'Manhattan';
-
-  :: 
-   
-    13965.3201224118
-
-  or...
-
-  .. code-block:: sql
-
-    SELECT Sum(ST_Area(geom)) / 4047
-      FROM nyc_census_blocks
-      WHERE boroname = 'Manhattan';
-
-  :: 
-   
-    14601.3987215548
-
 
 * **"How many census blocks in New York City have a hole in them?"**
- 
-  .. code-block:: sql
 
-    SELECT Count(*) 
-      FROM nyc_census_blocks
-      WHERE ST_NumInteriorRings(ST_GeometryN(geom,1)) > 0;
-
-  .. note::
-   
-    The ST_NRings() functions might be tempting, but it also counts the exterior rings of multi-polygons as well as interior rings.  In order to run ST_NumInteriorRings() we need to convert the MultiPolygon geometries of the blocks into simple polygons, so we extract the first polygon from each collection using ST_GeometryN(). Yuck!
-
-  :: 
-   
-    43
-   
 * **"What is the total length of streets (in kilometers) in New York City?"** (Hint: The units of measurement of the spatial data are meters, there are 1000 meters in a kilometer.)
-  
-  .. code-block:: sql
-
-    SELECT Sum(ST_Length(geom)) / 1000
-      FROM nyc_streets;
-
-  :: 
-   
-    10418.9047172
 
 * **"How long is 'Columbus Cir' (Columbus Circle)?**
- 
-  .. code-block:: sql
- 
-    SELECT ST_Length(geom)
-      FROM nyc_streets
-      WHERE name = 'Columbus Cir';
-
-  :: 
-   
-    308.34199
 
 * **"What is the JSON representation of the boundary of the 'West Village'?"**
- 
-  .. code-block:: sql
 
-    SELECT ST_AsGeoJSON(geom)
-      FROM nyc_neighborhoods
-      WHERE name = 'West Village';
-
-  ::
-     
-    {"type":"MultiPolygon","coordinates":
-     [[[[583263.2776595836,4509242.6260239873],
-        [583276.81990686338,4509378.825446927], ...
-        [583263.2776595836,4509242.6260239873]]]]}
-
-  The geometry type is "MultiPolygon", interesting!
-   
 * **"How many polygons are in the 'West Village' multipolygon?"**
- 
-  .. code-block:: sql
 
-    SELECT ST_NumGeometries(geom)
-      FROM nyc_neighborhoods
-      WHERE name = 'West Village';
-
-  ::
-
-    1
-       
-  .. note::
-   
-    It is not uncommon to find single-element MultiPolygons in spatial tables. Using MultiPolygons allows a table with only one geometry type to store both single- and multi-geometries without using mixed types.
-       
-       
 * **"What is the length of streets in New York City, summarized by type?"**
- 
-  .. code-block:: sql
-
-    SELECT type, Sum(ST_Length(geom)) AS length
-    FROM nyc_streets
-    GROUP BY type
-    ORDER BY length DESC;
-
-  ::
-   
-                           type                       |      length      
-    --------------------------------------------------+------------------
-     residential                                      | 8629870.33786606
-     motorway                                         | 403622.478126363
-     tertiary                                         | 360394.879051303
-     motorway_link                                    | 294261.419479668
-     secondary                                        | 276264.303897926
-     unclassified                                     | 166936.371604458
-     primary                                          | 135034.233017947
-     footway                                          | 71798.4878378096
-     service                                          |  28337.635038596
-     trunk                                            | 20353.5819826076
-     cycleway                                         | 8863.75144825929
-     pedestrian                                       | 4867.05032825026
-     construction                                     | 4803.08162103562
-     residential; motorway_link                       | 3661.57506293745
-     trunk_link                                       | 3202.18981240201
-     primary_link                                     | 2492.57457083536
-     living_street                                    | 1894.63905457332
-     primary; residential; motorway_link; residential | 1367.76576941335
-     undefined                                        |  380.53861910346
-     steps                                            | 282.745221342127
-     motorway_link; residential                       |  215.07778911517
-
-    
-  .. note::
-
-    The ``ORDER BY length DESC`` clause sorts the result by length in descending order. The result is that most prevalent types are first in the list.
-
- 

--- a/workshops/postgis/source/en/index.rst
+++ b/workshops/postgis/source/en/index.rst
@@ -14,13 +14,13 @@ Workshop Materials
 
 Inside the data bundle, you will find:
 
-**workshop/** 
+**workshop/**
   a directory containing this HTML workshop
 
-**data/** 
+**data/**
   a directory containing the shapefiles we will be loading
 
-All the data in the package is public domain and freely redistributable. All the software in the package is open source, and freely redistributable. This workshop is licensed as Creative Commons "`share alike with attribution <http://creativecommons.org/licenses/by-sa/3.0/us/>`_", and is freely redistributable under the terms of that license. 
+All the data in the package is public domain and freely redistributable. All the software in the package is open source, and freely redistributable. This workshop is licensed as Creative Commons "`share alike with attribution <http://creativecommons.org/licenses/by-sa/3.0/us/>`_", and is freely redistributable under the terms of that license.
 
 Workshop Modules
 ----------------
@@ -29,7 +29,7 @@ Workshop Modules
    :maxdepth: 1
    :numbered:
 
-   welcome 
+   welcome
    introduction
    installation
    creating_db
@@ -37,15 +37,20 @@ Workshop Modules
    about_data
    simple_sql
    simple_sql_exercises
+   simple_sql_exercise_answers
    geometries
    geometries_exercises
+   geometries_exercise_answers
    spatial_relationships
    spatial_relationships_exercises
+   spatial_relationships_exercise_answers
    joins
    joins_exercises
+   joins_exercise_answers
    indexing
    projection
-   projection_exercises   
+   projection_exercises
+   projection_exercise_answers
    geography
    geometry_returning
    joins_advanced
@@ -72,11 +77,11 @@ Workshop Modules
 Links to have on hand
 ---------------------
 
-* PostGIS - http://postgis.net/ 
+* PostGIS - http://postgis.net/
 
   - Docs - http://postgis.net/docs/manual-2.1/
 
-* PostgreSQL - http://www.postgresql.org/ 
+* PostgreSQL - http://www.postgresql.org/
 
   - Docs - http://www.postgresql.org/docs/
   - Downloads - http://www.postgresql.org/download/
@@ -85,11 +90,10 @@ Links to have on hand
   - Python Driver - http://www.pygresql.org/
   - C/C++ Driver - http://www.postgresql.org/docs/9.1/static/libpq.html
 
-* PgAdmin III - http://www.pgadmin.org/ 
+* PgAdmin III - http://www.pgadmin.org/
 
 * Open Source Desktop Clients
 
   - QGIS - http://qgis.org/
   - OpenJUMP - http://openjump.org/
   - uDig - http://udig.refractions.net/
-

--- a/workshops/postgis/source/en/joins_exercise_answers.rst
+++ b/workshops/postgis/source/en/joins_exercise_answers.rst
@@ -1,0 +1,94 @@
+.. _joins_exercise_answers:
+
+Spatial Joins Exercises with Answers
+====================================
+
+Exercises with Answers
+----------------------
+
+* **"What subway station is in 'Little Italy'? What subway route is it on?"**
+
+  .. code-block:: sql
+
+    SELECT s.name, s.routes
+    FROM nyc_subway_stations AS s
+    JOIN nyc_neighborhoods AS n
+    ON ST_Contains(n.geom, s.geom)
+    WHERE n.name = 'Little Italy';
+
+  .. note:: Recall: the function ``AS`` is used to give a table another name by using an alias, which can make queries easier to read and write. In this case, ``s`` is an alias for ``nyc_subway_stations``, ``n`` is an alias for ``nyc_neighborhoods``, ``s.name`` refers to the name column in the ``nyc_subway_stations`` table, etc.
+
+  ::
+
+      name    | routes
+   -----------+--------
+    Spring St | 6
+
+* **"What are all the neighborhoods served by the 6-train?"** (Hint: The ``routes`` column in the ``nyc_subway_stations`` table has values like 'B,D,6,V' and 'C,6')
+
+  .. code-block:: sql
+
+    SELECT DISTINCT n.name, n.boroname
+    FROM nyc_subway_stations AS s
+    JOIN nyc_neighborhoods AS n
+    ON ST_Contains(n.geom, s.geom)
+    WHERE strpos(s.routes,'6') > 0;
+
+  ::
+
+            name        | boroname
+    --------------------+-----------
+     Midtown            | Manhattan
+     Hunts Point        | The Bronx
+     Gramercy           | Manhattan
+     Little Italy       | Manhattan
+     Financial District | Manhattan
+     South Bronx        | The Bronx
+     Yorkville          | Manhattan
+     Murray Hill        | Manhattan
+     Mott Haven         | The Bronx
+     Upper East Side    | Manhattan
+     Chinatown          | Manhattan
+     East Harlem        | Manhattan
+     Greenwich Village  | Manhattan
+     Parkchester        | The Bronx
+     Soundview          | The Bronx
+
+  .. note::
+
+    We used the ``DISTINCT`` keyword to remove duplicate values from our result set where there were more than one subway station in a neighborhood.
+
+* **"After 9/11, the 'Battery Park' neighborhood was off limits for several days. How many people had to be evacuated?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(popn_total)
+    FROM nyc_neighborhoods AS n
+    JOIN nyc_census_blocks AS c
+    ON ST_Intersects(n.geom, c.geom)
+    WHERE n.name = 'Battery Park';
+
+  ::
+
+    17153
+
+* **"What are the population density (people / km^2) of the 'Upper West Side' and 'Upper East Side'?"** (Hint: There are 1000000 m^2 in one km^2.)
+
+  .. code-block:: sql
+
+    SELECT
+      n.name,
+      Sum(c.popn_total) / (ST_Area(n.geom) / 1000000.0) AS popn_per_sqkm
+    FROM nyc_census_blocks AS c
+    JOIN nyc_neighborhoods AS n
+    ON ST_Intersects(c.geom, n.geom)
+    WHERE n.name = 'Upper West Side'
+    OR n.name = 'Upper East Side'
+    GROUP BY n.name, n.geom;
+
+  ::
+
+          name       |  popn_per_sqkm
+    -----------------+------------------
+     Upper East Side | 48524.4877489857
+     Upper West Side | 40152.4896080024

--- a/workshops/postgis/source/en/joins_exercises.rst
+++ b/workshops/postgis/source/en/joins_exercises.rst
@@ -9,7 +9,7 @@ Here's a reminder of some of the functions we have seen.  Hint: they should be u
 * :command:`count(expression)`: aggregate to return the size of a set of records
 * :command:`ST_Area(geometry)` returns the area of the polygons
 * :command:`ST_AsText(geometry)` returns WKT ``text``
-* :command:`ST_Contains(geometry A, geometry B)` returns the true if geometry A contains geometry B 
+* :command:`ST_Contains(geometry A, geometry B)` returns the true if geometry A contains geometry B
 * :command:`ST_Distance(geometry A, geometry B)` returns the minimum distance between geometry A and geometry B
 * :command:`ST_DWithin(geometry A, geometry B, radius)` returns the true if geometry A is radius distance or less from geometry B
 * :command:`ST_GeomFromText(text)` returns ``geometry``
@@ -17,113 +17,32 @@ Here's a reminder of some of the functions we have seen.  Hint: they should be u
 * :command:`ST_Length(linestring)` returns the length of the linestring
 * :command:`ST_Touches(geometry A, geometry B)` returns the true if the boundary of geometry A touches geometry B
 * :command:`ST_Within(geometry A, geometry B)` returns the true if geometry A is within geometry B
- 
+
 Also remember the tables we have available:
 
-* ``nyc_census_blocks`` 
- 
+* ``nyc_census_blocks``
+
   * name, popn_total, boroname, geom
- 
+
 * ``nyc_streets``
- 
+
   * name, type, geom
-   
+
 * ``nyc_subway_stations``
- 
+
   * name, routes, geom
- 
+
 * ``nyc_neighborhoods``
- 
+
   * name, boroname, geom
 
 Exercises
 ---------
 
 * **"What subway station is in 'Little Italy'? What subway route is it on?"**
- 
-  .. code-block:: sql
- 
-    SELECT s.name, s.routes 
-    FROM nyc_subway_stations AS s
-    JOIN nyc_neighborhoods AS n 
-    ON ST_Contains(n.geom, s.geom)  
-    WHERE n.name = 'Little Italy';
 
-  .. note:: Recall: the function ``AS`` is used to give a table another name by using an alias, which can make queries easier to read and write. In this case, ``s`` is an alias for ``nyc_subway_stations``, ``n`` is an alias for ``nyc_neighborhoods``, ``s.name`` refers to the name column in the ``nyc_subway_stations`` table, etc. 
-
-  :: 
-  
-      name    | routes 
-   -----------+--------
-    Spring St | 6
-   
 * **"What are all the neighborhoods served by the 6-train?"** (Hint: The ``routes`` column in the ``nyc_subway_stations`` table has values like 'B,D,6,V' and 'C,6')
- 
-  .. code-block:: sql
-  
-    SELECT DISTINCT n.name, n.boroname 
-    FROM nyc_subway_stations AS s
-    JOIN nyc_neighborhoods AS n 
-    ON ST_Contains(n.geom, s.geom)  
-    WHERE strpos(s.routes,'6') > 0;
-    
-  ::
-  
-            name        | boroname  
-    --------------------+-----------
-     Midtown            | Manhattan
-     Hunts Point        | The Bronx
-     Gramercy           | Manhattan
-     Little Italy       | Manhattan
-     Financial District | Manhattan
-     South Bronx        | The Bronx
-     Yorkville          | Manhattan
-     Murray Hill        | Manhattan
-     Mott Haven         | The Bronx
-     Upper East Side    | Manhattan
-     Chinatown          | Manhattan
-     East Harlem        | Manhattan
-     Greenwich Village  | Manhattan
-     Parkchester        | The Bronx
-     Soundview          | The Bronx
 
-  .. note::
-  
-    We used the ``DISTINCT`` keyword to remove duplicate values from our result set where there were more than one subway station in a neighborhood.
-    
 * **"After 9/11, the 'Battery Park' neighborhood was off limits for several days. How many people had to be evacuated?"**
- 
-  .. code-block:: sql
- 
-    SELECT Sum(popn_total)
-    FROM nyc_neighborhoods AS n
-    JOIN nyc_census_blocks AS c 
-    ON ST_Intersects(n.geom, c.geom)  
-    WHERE n.name = 'Battery Park';
-   
-  :: 
 
-    17153
-    
 * **"What are the population density (people / km^2) of the 'Upper West Side' and 'Upper East Side'?"** (Hint: There are 1000000 m^2 in one km^2.)
- 
-  .. code-block:: sql
-   
-    SELECT 
-      n.name, 
-      Sum(c.popn_total) / (ST_Area(n.geom) / 1000000.0) AS popn_per_sqkm
-    FROM nyc_census_blocks AS c
-    JOIN nyc_neighborhoods AS n
-    ON ST_Intersects(c.geom, n.geom)
-    WHERE n.name = 'Upper West Side'
-    OR n.name = 'Upper East Side'
-    GROUP BY n.name, n.geom;
-     
-  ::
-   
-          name       |  popn_per_sqkm   
-    -----------------+------------------
-     Upper East Side | 48524.4877489857
-     Upper West Side | 40152.4896080024
-
-     

--- a/workshops/postgis/source/en/projection_exercise_answers.rst
+++ b/workshops/postgis/source/en/projection_exercise_answers.rst
@@ -1,0 +1,90 @@
+.. _projection_exercise_answers:
+
+Projection Exercises with Answers
+=================================
+
+Exercises with Answers
+----------------------
+
+* **"What is the length of all streets in New York, as measured in UTM 18?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(ST_Length(geom))
+      FROM nyc_streets;
+
+  ::
+
+    10418904.7172
+
+* **"What is the WKT definition of SRID 2831?"**
+
+  .. code-block:: sql
+
+    SELECT srtext FROM spatial_ref_sys
+    WHERE SRID = 2831;
+
+  Or, via `prj2epsg <http://prj2epsg.org/epsg/2831>`_
+
+  ::
+
+    PROJCS["NAD83(HARN) / New York Long Island",
+      GEOGCS["NAD83(HARN)",
+        DATUM["NAD83 (High Accuracy Regional Network)",
+          SPHEROID["GRS 1980", 6378137.0, 298.257222101,
+            AUTHORITY["EPSG","7019"]],
+          TOWGS84[-0.991, 1.9072, 0.5129, 0.0257899075194932, -0.009650098960270402, -0.011659943232342112, 0.0],
+          AUTHORITY["EPSG","6152"]],
+        PRIMEM["Greenwich", 0.0,
+          AUTHORITY["EPSG","8901"]],
+        UNIT["degree", 0.017453292519943295],
+        AXIS["Geodetic longitude", EAST],
+        AXIS["Geodetic latitude", NORTH],
+        AUTHORITY["EPSG","4152"]],
+      PROJECTION["Lambert Conic Conformal (2SP)",
+        AUTHORITY["EPSG","9802"]],
+      PARAMETER["central_meridian", -74.0],
+      PARAMETER["latitude_of_origin", 40.166666666666664],
+      PARAMETER["standard_parallel_1", 41.03333333333333],
+      PARAMETER["false_easting", 300000.0],
+      PARAMETER["false_northing", 0.0],
+      PARAMETER["scale_factor", 1.0],
+      PARAMETER["standard_parallel_2", 40.666666666666664],
+      UNIT["m", 1.0],
+      AXIS["Easting", EAST],
+      AXIS["Northing", NORTH],
+      AUTHORITY["EPSG","2831"]]
+
+
+* **"What is the length of all streets in New York, as measured in SRID 2831?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(ST_Length(ST_Transform(geom,2831)))
+      FROM nyc_streets;
+
+  ::
+
+    10421993.706374
+
+  .. note::
+
+    The difference between the UTM 18 and the State Plane Long Island measurements is (10421993 - 10418904)/10418904, or 0.02%. Calculated on the spheroid using :ref:`geography` the total street length is 10421999, which is closer to the State Plane value. This is not surprising, since the State Plane Long Island projection is precisely calibrated for a very small area (New York City) while UTM 18 has to provide reasonable results for a large regional area.
+
+* **"What is the KML representation of the point at 'Broad St' subway station?"**
+
+  .. code-block:: sql
+
+    SELECT ST_AsKML(geom)
+    FROM nyc_subway_stations
+    WHERE name = 'Broad St';
+
+  ::
+
+    <Point>
+      <coordinates>
+        -74.010671468873468,40.707104815584088
+      </coordinates>
+    </Point>
+
+  Hey! The coordinates are in geographics even though we didn't call :command:`ST_Transform`, why? Because the KML standard dictates that all coordinates *must* be in geographics (ESPG:4326, in fact) so the :command:`ST_AsKML` function does the transformation automatically.

--- a/workshops/postgis/source/en/projection_exercises.rst
+++ b/workshops/postgis/source/en/projection_exercises.rst
@@ -20,104 +20,29 @@ Remember the online resources that are available to you:
 
 Also remember the tables we have available:
 
-* ``nyc_census_blocks`` 
- 
+* ``nyc_census_blocks``
+
   * name, popn_total, boroname, geom
- 
+
 * ``nyc_streets``
- 
+
   * name, type, geom
-   
+
 * ``nyc_subway_stations``
- 
+
   * name, geom
- 
+
 * ``nyc_neighborhoods``
- 
+
   * name, boroname, geom
 
 Exercises
 ---------
 
 * **"What is the length of all streets in New York, as measured in UTM 18?"**
- 
-  .. code-block:: sql
 
-    SELECT Sum(ST_Length(geom))
-      FROM nyc_streets;
-
-  :: 
-  
-    10418904.7172
-      
-* **"What is the WKT definition of SRID 2831?"**   
-    
-  .. code-block:: sql
-
-    SELECT srtext FROM spatial_ref_sys
-    WHERE SRID = 2831;
-
-  Or, via `prj2epsg <http://prj2epsg.org/epsg/2831>`_
-
-  ::
-
-    PROJCS["NAD83(HARN) / New York Long Island", 
-      GEOGCS["NAD83(HARN)", 
-        DATUM["NAD83 (High Accuracy Regional Network)", 
-          SPHEROID["GRS 1980", 6378137.0, 298.257222101, 
-            AUTHORITY["EPSG","7019"]], 
-          TOWGS84[-0.991, 1.9072, 0.5129, 0.0257899075194932, -0.009650098960270402, -0.011659943232342112, 0.0], 
-          AUTHORITY["EPSG","6152"]], 
-        PRIMEM["Greenwich", 0.0, 
-          AUTHORITY["EPSG","8901"]], 
-        UNIT["degree", 0.017453292519943295], 
-        AXIS["Geodetic longitude", EAST], 
-        AXIS["Geodetic latitude", NORTH], 
-        AUTHORITY["EPSG","4152"]], 
-      PROJECTION["Lambert Conic Conformal (2SP)", 
-        AUTHORITY["EPSG","9802"]], 
-      PARAMETER["central_meridian", -74.0], 
-      PARAMETER["latitude_of_origin", 40.166666666666664], 
-      PARAMETER["standard_parallel_1", 41.03333333333333], 
-      PARAMETER["false_easting", 300000.0], 
-      PARAMETER["false_northing", 0.0], 
-      PARAMETER["scale_factor", 1.0], 
-      PARAMETER["standard_parallel_2", 40.666666666666664], 
-      UNIT["m", 1.0], 
-      AXIS["Easting", EAST], 
-      AXIS["Northing", NORTH], 
-      AUTHORITY["EPSG","2831"]]
-  
+* **"What is the WKT definition of SRID 2831?"**
 
 * **"What is the length of all streets in New York, as measured in SRID 2831?"**
- 
-  .. code-block:: sql
 
-    SELECT Sum(ST_Length(ST_Transform(geom,2831)))
-      FROM nyc_streets;
-
-  :: 
-   
-    10421993.706374
-     
-  .. note::
-   
-    The difference between the UTM 18 and the State Plane Long Island measurements is (10421993 - 10418904)/10418904, or 0.02%. Calculated on the spheroid using :ref:`geography` the total street length is 10421999, which is closer to the State Plane value. This is not surprising, since the State Plane Long Island projection is precisely calibrated for a very small area (New York City) while UTM 18 has to provide reasonable results for a large regional area.
-     
 * **"What is the KML representation of the point at 'Broad St' subway station?"**
- 
-  .. code-block:: sql
-   
-    SELECT ST_AsKML(geom) 
-    FROM nyc_subway_stations
-    WHERE name = 'Broad St';
-     
-  :: 
-   
-    <Point>
-      <coordinates>
-        -74.010671468873468,40.707104815584088
-      </coordinates>
-    </Point>
-     
-  Hey! The coordinates are in geographics even though we didn't call :command:`ST_Transform`, why? Because the KML standard dictates that all coordinates *must* be in geographics (ESPG:4326, in fact) so the :command:`ST_AsKML` function does the transformation automatically.

--- a/workshops/postgis/source/en/simple_sql_exercise_answers.rst
+++ b/workshops/postgis/source/en/simple_sql_exercise_answers.rst
@@ -1,0 +1,53 @@
+.. _simple_sql_exercise_answers:
+
+Simple SQL Exercise Answers
+===========================
+
+Now the questions with answers:
+
+* **"What is the population of the City of New York?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(popn_total) AS population
+      FROM nyc_census_blocks;
+
+  ::
+
+    8175032
+
+  .. note::
+
+    What is this ``AS``? You can give a table or a column another name by using an alias.  Aliases can make queries easier to both write and to read. So instead of our outputted column name as ``sum`` we write it **AS** the more readable ``population``.
+
+* **"What is the population of the Bronx?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(popn_total) AS population
+      FROM nyc_census_blocks
+      WHERE boroname = 'The Bronx';
+
+  ::
+
+    1385108
+
+* **"For each borough, what percentage of the population is white?"**
+
+  .. code-block:: sql
+
+    SELECT
+      boroname,
+      100 * Sum(popn_white)/Sum(popn_total) AS white_pct
+    FROM nyc_census_blocks
+    GROUP BY boroname;
+
+  ::
+
+       boroname    |    white_pct
+    ---------------+------------------
+     Brooklyn      | 42.8011737932687
+     Manhattan     | 57.4493039480463
+     The Bronx     | 27.9037446899448
+     Queens        |  39.722077394591
+     Staten Island | 72.8942034860154

--- a/workshops/postgis/source/en/simple_sql_exercises.rst
+++ b/workshops/postgis/source/en/simple_sql_exercises.rst
@@ -3,7 +3,7 @@
 Simple SQL Exercises
 ====================
 
-Using the ``nyc_census_blocks`` table, answer the following questions (don't peak at the answers!). 
+Using the ``nyc_census_blocks`` table, answer the following questions (don't peak at the answers!).
 
 Here is some helpful information to get started.  Recall from the :ref:`About Our Data <about_data>` section our ``nyc_census_blocks`` table definition.
 
@@ -44,52 +44,11 @@ And, here are some common SQL aggregation functions you might find useful:
 Now the questions:
 
 * **"What is the population of the City of New York?"**
- 
-  .. code-block:: sql
-   
-    SELECT Sum(popn_total) AS population
-      FROM nyc_census_blocks;
-     
-  :: 
-   
-    8175032 
-   
-  .. note:: 
-   
-    What is this ``AS``? You can give a table or a column another name by using an alias.  Aliases can make queries easier to both write and to read. So instead of our outputted column name as ``sum`` we write it **AS** the more readable ``population``. 
-       
+
 * **"What is the population of the Bronx?"**
 
-  .. code-block:: sql
- 
-    SELECT Sum(popn_total) AS population
-      FROM nyc_census_blocks
-      WHERE boroname = 'The Bronx';
-     
-  :: 
-   
-    1385108 
-  
 * **"For each borough, what percentage of the population is white?"**
 
-  .. code-block:: sql
-
-    SELECT 
-      boroname, 
-      100 * Sum(popn_white)/Sum(popn_total) AS white_pct
-    FROM nyc_census_blocks
-    GROUP BY boroname;
-
-  :: 
-   
-       boroname    |    white_pct     
-    ---------------+------------------
-     Brooklyn      | 42.8011737932687
-     Manhattan     | 57.4493039480463
-     The Bronx     | 27.9037446899448
-     Queens        |  39.722077394591
-     Staten Island | 72.8942034860154
-   
  
 Function List
 -------------

--- a/workshops/postgis/source/en/spatial_relationships_exercise_answers.rst
+++ b/workshops/postgis/source/en/spatial_relationships_exercise_answers.rst
@@ -1,0 +1,81 @@
+.. _spatial_relationships_exercise_answers:
+
+Spatial Relationships Exercise Answers
+======================================
+
+Exercises with answers
+----------------------
+
+* **"What is the geometry value for the street named 'Atlantic Commons'?"**
+
+  .. code-block:: sql
+
+    SELECT ST_AsText(geom)
+      FROM nyc_streets
+      WHERE name = 'Atlantic Commons';
+
+  ::
+
+    MULTILINESTRING((586781.701577724 4504202.15314339,586863.51964484 4504215.9881701))
+
+* **"What neighborhood and borough is Atlantic Commons in?"**
+
+  .. code-block:: sql
+
+    SELECT name, boroname
+    FROM nyc_neighborhoods
+    WHERE ST_Intersects(
+      geom,
+      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918)
+    );
+
+  ::
+
+        name    | boroname
+    ------------+----------
+     Fort Green | Brooklyn
+
+  .. note::
+
+    "Hey, why did you change from a 'MULTILINESTRING' to a 'LINESTRING'?" Spatially they describe the same shape, so going from a single-item multi-geometry to a singleton saves a few keystrokes.
+
+    More importantly, we also rounded the coordinates to make them easier to read, which does actually change results: we couldn't use the ST_Touches() predicate to find out which roads join Atlantic Commons, because the coordinates are not exactly the same anymore.
+
+
+* **"What streets does Atlantic Commons join with?"**
+
+  .. code-block:: sql
+
+    SELECT name
+    FROM nyc_streets
+    WHERE ST_DWithin(
+      geom,
+      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
+      0.1
+    );
+
+  ::
+
+           name
+      ------------------
+       Cumberland St
+       Atlantic Commons
+
+  .. image:: ./spatial_relationships/atlantic_commons.jpg
+
+
+* **"Approximately how many people live on (within 50 meters of) Atlantic Commons?"**
+
+  .. code-block:: sql
+
+    SELECT Sum(popn_total)
+      FROM nyc_census_blocks
+      WHERE ST_DWithin(
+       geom,
+       ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
+       50
+      );
+
+  ::
+
+    1438

--- a/workshops/postgis/source/en/spatial_relationships_exercises.rst
+++ b/workshops/postgis/source/en/spatial_relationships_exercises.rst
@@ -7,9 +7,9 @@ Here's a reminder of the functions we saw in the last section. They should be us
 
 * :command:`sum(expression)` aggregate to return a sum for a set of records
 * :command:`count(expression)` aggregate to return the size of a set of records
-* :command:`ST_Contains(geometry A, geometry B)` returns true if geometry A contains geometry B 
+* :command:`ST_Contains(geometry A, geometry B)` returns true if geometry A contains geometry B
 * :command:`ST_Crosses(geometry A, geometry B)` returns true if geometry A crosses geometry B
-* :command:`ST_Disjoint(geometry A , geometry B)` returns true if the geometries do not "spatially intersect" 
+* :command:`ST_Disjoint(geometry A , geometry B)` returns true if the geometries do not "spatially intersect"
 * :command:`ST_Distance(geometry A, geometry B)` returns the minimum distance between geometry A and geometry B
 * :command:`ST_DWithin(geometry A, geometry B, radius)` returns true if geometry A is radius distance or less from geometry B
 * :command:`ST_Equals(geometry A, geometry B)` returns true if geometry A is the same as geometry B
@@ -20,96 +20,29 @@ Here's a reminder of the functions we saw in the last section. They should be us
 
 Also remember the tables we have available:
 
-* ``nyc_census_blocks`` 
- 
+* ``nyc_census_blocks``
+
   * blkid, popn_total, boroname, geom
- 
+
 * ``nyc_streets``
- 
+
   * name, type, geom
-   
+
 * ``nyc_subway_stations``
- 
+
   * name, geom
- 
+
 * ``nyc_neighborhoods``
- 
+
   * name, boroname, geom
 
 Exercises
 ---------
 
 * **"What is the geometry value for the street named 'Atlantic Commons'?"**
- 
-  .. code-block:: sql
 
-    SELECT ST_AsText(geom)
-      FROM nyc_streets
-      WHERE name = 'Atlantic Commons';
-
-  ::
-   
-    MULTILINESTRING((586781.701577724 4504202.15314339,586863.51964484 4504215.9881701))
-     
 * **"What neighborhood and borough is Atlantic Commons in?"**
-     
-  .. code-block:: sql
-
-    SELECT name, boroname 
-    FROM nyc_neighborhoods 
-    WHERE ST_Intersects(
-      geom,
-      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918)
-    );
-
-  ::
-     
-        name    | boroname 
-    ------------+----------
-     Fort Green | Brooklyn
-     
-  .. note::
-   
-    "Hey, why did you change from a 'MULTILINESTRING' to a 'LINESTRING'?" Spatially they describe the same shape, so going from a single-item multi-geometry to a singleton saves a few keystrokes. 
-      
-    More importantly, we also rounded the coordinates to make them easier to read, which does actually change results: we couldn't use the ST_Touches() predicate to find out which roads join Atlantic Commons, because the coordinates are not exactly the same anymore.
-
 
 * **"What streets does Atlantic Commons join with?"**
- 
-  .. code-block:: sql
-
-    SELECT name 
-    FROM nyc_streets 
-    WHERE ST_DWithin(
-      geom, 
-      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
-      0.1
-    );
-    
-  ::
-  
-           name
-      ------------------
-       Cumberland St
-       Atlantic Commons
-
-  .. image:: ./spatial_relationships/atlantic_commons.jpg
-  
 
 * **"Approximately how many people live on (within 50 meters of) Atlantic Commons?"**
- 
-  .. code-block:: sql
-
-    SELECT Sum(popn_total)
-      FROM nyc_census_blocks
-      WHERE ST_DWithin(
-       geom,
-       ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
-       50
-      );
-        
-  :: 
-   
-    1438 
-   


### PR DESCRIPTION
I've separated the answers out into their own pages.  This makes it easier as the instructor to keep all the questions on screen and walk around to watch people work on them, rather than have the answers displayed simultaneously.